### PR TITLE
Add Respoke-SDK header to requests

### DIFF
--- a/respoke/RespokeClient.cs
+++ b/respoke/RespokeClient.cs
@@ -2,12 +2,19 @@
 using System.Net;
 using System.IO;
 using System.Text;
+using System.Reflection;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Respoke;
 
 namespace Respoke {
 	public class RespokeClient {
+		private string GetSDKHeader() {
+			string version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+			string os = Environment.OSVersion.ToString();
+			string clrVersion = Environment.Version.ToString();
+			return "Respoke-.NET/" + version + " (" + os + ") .NET-CLR/" + clrVersion;
+		}
 
 		public string BaseUrl { get; set; }
 
@@ -23,7 +30,7 @@ namespace Respoke {
 			WebRequest req = WebRequest.Create(BaseUrl + parms.Path);
 			req.Method = parms.Method;
 			req.ContentType = "application/json";
-			((HttpWebRequest)req).UserAgent = "Respoke .NET Client";
+			req.Headers.Add("Respoke-SDK: " + GetSDKHeader());
 
 			if (parms.AppSecret != null) {
 				req.Headers.Add("App-Secret: " + parms.AppSecret);


### PR DESCRIPTION
This patch adds the "Respoke-SDK" header containing the library
version, rough operating system version, and the .net CLR version.
I was disappointed to find that it is very difficult to find the
.net platform version that the app is running, so the CLR version
was the next best thing. The operating system that is reported is a
very rough value. On Mac, it reports "Unix". However, it's good enough
for now and if we decide we need more granular information later
we can improve on it.

<img width="718" alt="screen shot 2015-09-23 at 5 46 56 pm" src="https://cloud.githubusercontent.com/assets/309219/10061036/26422108-621b-11e5-8aca-e7b97a55a99c.png">

Related to MER-4340.
